### PR TITLE
Python 2 Support

### DIFF
--- a/python/faasclient/api.py
+++ b/python/faasclient/api.py
@@ -1,4 +1,7 @@
-from urllib.parse import urljoin
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
 import re
 import time
 import simplejson as json


### PR DESCRIPTION
`urllib` package changed its API in python 3, which breaks compatibility with any project that uses python 2. Should probably attempt to support both versions of python for the time being.